### PR TITLE
Fix duplicates error on discovery with require hostname enabled

### DIFF
--- a/library/Nmap/ProvidedHook/Director/ImportSource.php
+++ b/library/Nmap/ProvidedHook/Director/ImportSource.php
@@ -27,6 +27,7 @@ class ImportSource extends ImportSourceHook
                         'mac' => $currentMac,
                         'host' => $currentHost,
                     ];
+		    $currentIp = $currentMac = $currentHost = null;
                 }
                 $currentIp = $m[2];
                 $currentHost = $m[1];
@@ -38,6 +39,7 @@ class ImportSource extends ImportSourceHook
                         'mac' => $currentMac,
                         'host' => $currentHost,
                     ];
+		    $currentIp = $currentMac = $currentHost = null;
                 }
                 if ($requireHost === 'y') {
                     $currentMac = null;


### PR DESCRIPTION
Launching a discovery with require hostname enabled might lead to a duplicate error.
This fix solves the issue.